### PR TITLE
Added loop when fetching unseal key from vaultwarden

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
       # The Docker Hub Repository you want eventually push to, e.g samply/share-client
       image-name: "samply/vaultfetcher"
       # Where to push your images ("dockerhub", "ghcr", "both" or "none")
-      push-to: dockerhub
+      push-to: docker.io
       # Define special prefixes for docker tags. They will prefix each images tag.
       # image-tag-prefix: "foo"
       # Define the build context of your image, typically default '.' will be enough

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,6 @@
-FROM rust AS builder
+FROM alpine
 
-RUN echo '[profile.release]\n\
-lto = true\n\
-codegen-units = 1\n\
-panic = "abort"\n\
-strip = true' > $CARGO_HOME/config.toml
-
-RUN cargo install rbw && \
-    mv $CARGO_HOME/bin/rbw $CARGO_HOME/bin/rbw-agent /
-
-FROM ubuntu
-
-RUN apt-get update && \
-    apt-get -y install jq curl && \
-    rm -rf /var/lib/apt/lists
-
-COPY --from=builder /rbw /rbw-agent /usr/local/bin/
+RUN apk --no-cache add jq curl bash rbw
 
 ADD *.sh /
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,7 +8,7 @@ source ./checkMandVars.sh
 
 export PIN=$(mktemp)
 
-bw_login() {
+bw_setconfig() {
 	cat <<EOF > ${PIN}
 #!/bin/sh
 
@@ -20,7 +20,7 @@ EOF
 	rbw config set pinentry ${PIN}
 }
 
-bw_logout(){
+bw_stopagent(){
 	rbw stop-agent
 }
 
@@ -36,7 +36,7 @@ case "$1" in
 			exit 1
 		fi
 
-		bw_login
+		bw_setconfig
 		RESULT="\n"
 
 		while (( "$#" )); do
@@ -51,22 +51,21 @@ case "$1" in
 
 		echo -e "$RESULT"
 
-		bw_logout
+		bw_stopagent
 		;;
 
 	unsealVault)
 		shift
 
-		WAITING=1
-		while [ $WAITING -eq 1 ]; do
+		while true; do
 			case "$(vault_sealstatus)" in
 				true)
 					echo "Vault is online and sealed. Unsealing Vault ..."
-					WAITING=0
+					break
 					;;
 				false)
 					echo "Vault is already unlocked."
-					WAITING=0
+					break
 					;;
 				*)
 					echo "Vault is not online yet -- waiting ..."
@@ -76,28 +75,21 @@ case "$1" in
 		done
 
 		if [ "$(vault_sealstatus)" == "true" ]; then
-			bw_login
+			bw_setconfig
 			echo "Getting unseal key ..."
-			WAITING=1
-			while [ $WAITING -eq 1 ]; do
-				if [ $? -eq 0 ]; then
-					read UNSEAL_KEY < <(rbw get "Vault Unseal Key")
-					WAITING=0
-				else
-				  echo "Waiting for vaultwarden to be reachable ..."
-				  sleep 3
-				fi
+			until read UNSEAL_KEY < <(rbw get "Vault Unseal Key"); do
+				echo "Waiting for vaultwarden to be reachable ..."
+				sleep 3
 			done
 			echo "Got unseal key."
-			bw_logout
-			RUNNING=1
-			while [ $RUNNING -eq 1 ]; do
+			bw_stopagent
+			while true; do
 				RES=$(curl -s \
 					--request POST \
 					--data "{ \"key\": \"${UNSEAL_KEY}\" }" \
 					${VAULT_ADDR}/v1/sys/unseal)
 				if [ "$(echo "$RES" | grep sealed | grep false)" != "" ]; then
-					RUNNING=0
+					break
 				else
 					echo "Failed to unlock vault. Retrying in 1 second."
 					sleep 1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -78,7 +78,16 @@ case "$1" in
 		if [ "$(vault_sealstatus)" == "true" ]; then
 			bw_login
 			echo "Getting unseal key ..."
-			read UNSEAL_KEY < <(rbw get "Vault Unseal Key")
+			WAITING=1
+			while [ $WAITING -eq 1 ]; do
+				if [ $? -eq 0 ]; then
+					read UNSEAL_KEY < <(rbw get "Vault Unseal Key")
+					WAITING=0
+				else
+				  echo "Waiting for vaultwarden to be reachable ..."
+				  sleep 3
+				fi
+			done
 			echo "Got unseal key."
 			bw_logout
 			RUNNING=1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -57,18 +57,21 @@ case "$1" in
 	unsealVault)
 		shift
 
+		UNSEAL_RETRY=0
 		while true; do
+			UNSEAL_RETRY=$(( UNSEAL_RETRY + 1 ))
+			echo "Attempt ${UNSEAL_RETRY}: Checking vault status ..."
 			case "$(vault_sealstatus)" in
 				true)
-					echo "Vault is online and sealed. Unsealing Vault ..."
+					echo "Attempt ${UNSEAL_RETRY}: Vault is online and sealed. Unsealing Vault ..."
 					break
 					;;
 				false)
-					echo "Vault is already unlocked."
+					echo "Attempt ${UNSEAL_RETRY}: Vault is already unlocked."
 					break
 					;;
 				*)
-					echo "Vault is not online yet -- waiting ..."
+					echo "Attempt ${UNSEAL_RETRY}: Vault is not online yet -- waiting ..."
 					sleep 1
 					;;
 			esac
@@ -83,15 +86,19 @@ case "$1" in
 			done
 			echo "Got unseal key."
 			bw_stopagent
+			UNSEAL_RETRY=0
 			while true; do
+				UNSEAL_RETRY=$(( UNSEAL_RETRY + 1 ))
+				echo "Attempt ${UNSEAL_RETRY}: Unsealing vault ..."
 				RES=$(curl -s \
 					--request POST \
 					--data "{ \"key\": \"${UNSEAL_KEY}\" }" \
 					${VAULT_ADDR}/v1/sys/unseal)
 				if [ "$(echo "$RES" | grep sealed | grep false)" != "" ]; then
+					echo "Attempt ${UNSEAL_RETRY}: Vault unsealed successfully."
 					break
 				else
-					echo "Failed to unlock vault. Retrying in 1 second."
+					echo "Attempt ${UNSEAL_RETRY}: Failed to unlock vault. Retrying in 1 second."
 					sleep 1
 				fi
 			done

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -79,14 +79,16 @@ case "$1" in
 			esac
 		done
 
+		UNSEAL_RETRY=0
 		if [ "$(vault_sealstatus)" == "true" ]; then
 			bw_setconfig
 			echo "Getting unseal key ..."
 			until read UNSEAL_KEY < <(rbw get "Vault Unseal Key"); do
-				echo "Waiting for vaultwarden to be reachable ..."
+				UNSEAL_RETRY=$(( UNSEAL_RETRY + 1 ))
+				echo "Attempt ${UNSEAL_RETRY}: Waiting for vaultwarden to be reachable ..."
 				sleep 3
 			done
-			echo "Got unseal key."
+			echo "Attempt ${UNSEAL_RETRY}: Got unseal key."
 			bw_stopagent
 			UNSEAL_RETRY=0
 			while true; do

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,6 +6,8 @@ export VAULT_ADDR=http://vault:8200
 
 source ./checkMandVars.sh
 
+trap 'echo "SIGTERM received, exiting..."; kill -- -$$ 2>/dev/null; exit 143' TERM
+
 export PIN=$(mktemp)
 
 bw_setconfig() {


### PR DESCRIPTION
As Vaultwarden sometimes seems to not be available directly after the local broker vault is online, we need to add a retry loop.
Please note: this is no full solution to the problem, as the broker will stop querying the vault after 300 secs. 

TODOs:
- [x] Test on test instance